### PR TITLE
APP-696 custom trust store instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ The GitHub Webhook Integration will allow you to receive notifications in Sympho
 As the GitHub admin of a repository, you can configure a WebHook to post messages to a URL you generate in the GitHub WebHook Application to start receiving notifications for the supported events. As of the current version, one must set the WebHook Content type to application/json, as shown below:
 
 ## Using a custom trust store
-GitHub integration connects to the GitHub service to retrieve information about GitHub users.
+GitHub integration connects to the GitHub service to retrieve information about users (user name) and display it on webhook events. 
+
+When using a custom truststore for the Integration Bridge, make sure it also includes the proper certificate to connect to the GitHub service. If GitHub is used as a cloud service, download the certificate from GitHub domain and add it to the custom trustore. In case GitHub is deployed on premises, make sure the truststore contains the certificate to connect to the on-prem server and the Integration Bridge can also access that server through the network.
+  
+In case the Integration Bridge can not access GitHub, webhooks will still work, but only usernames will be displayed on the events.
 
 ![Selecting content type](src/docs/sample/sample_webhook_content_type.png)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The GitHub Webhook Integration will allow you to receive notifications in Sympho
 ## How it works
 As the GitHub admin of a repository, you can configure a WebHook to post messages to a URL you generate in the GitHub WebHook Application to start receiving notifications for the supported events. As of the current version, one must set the WebHook Content type to application/json, as shown below:
 
+## Using a custom trust store
+GitHub integration connects to the GitHub service to retrieve information about GitHub users.
+
 ![Selecting content type](src/docs/sample/sample_webhook_content_type.png)
 
 ## What formats and events it supports and what it produces

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As the GitHub admin of a repository, you can configure a WebHook to post message
 ## Using a custom trust store
 GitHub integration connects to the GitHub service to retrieve information about users (user name) and display it on webhook events. 
 
-When using a custom truststore for the Integration Bridge, make sure it also includes the proper certificate to connect to the GitHub service. If GitHub is used as a cloud service, download the certificate from GitHub domain and add it to the custom trustore. In case GitHub is deployed on premises, make sure the truststore contains the certificate to connect to the on-prem server and the Integration Bridge can also access that server through the network.
+When using a custom trust store for the Integration Bridge, make sure it also includes the proper certificate to connect to the GitHub service. If GitHub is used as a cloud service, download the certificate from GitHub domain and add it to the custom trust store. In case GitHub is deployed on premises, make sure the trust store contains the certificate to connect to the on-prem server and the Integration Bridge can also access that server through the network.
   
 In case the Integration Bridge can not access GitHub, webhooks will still work, but only usernames will be displayed on the events.
 


### PR DESCRIPTION
Adding information regarding the access required by the GitHub integration to the GitHub Service, and how custom truststores should be built to support such access to both cloud and on-prem GitHub service.